### PR TITLE
Export function to be use-able in library

### DIFF
--- a/tracker/http.go
+++ b/tracker/http.go
@@ -56,7 +56,7 @@ func (me *Peers) UnmarshalBencode(b []byte) (err error) {
 		vars.Add("http responses with list peers", 1)
 		for _, i := range v {
 			var p Peer
-			p.fromDictInterface(i.(map[string]interface{}))
+			p.FromDictInterface(i.(map[string]interface{}))
 			*me = append(*me, p)
 		}
 		return

--- a/tracker/peer.go
+++ b/tracker/peer.go
@@ -13,7 +13,7 @@ type Peer struct {
 }
 
 // Set from the non-compact form in BEP 3.
-func (p *Peer) fromDictInterface(d map[string]interface{}) {
+func (p *Peer) FromDictInterface(d map[string]interface{}) {
 	p.IP = net.ParseIP(d["ip"].(string))
 	if _, ok := d["peer id"]; ok {
 		p.ID = []byte(d["peer id"].(string))


### PR DESCRIPTION
The method `fromDictInterface` was not exported from the `Peer` structure.

I feel like people using this `Peer` interface from outside the library would be happy to access this full method to instantiate peers from a non-compact format.
I'm in such a case actually, and i'm being force to fork the class in my project.